### PR TITLE
build: Re-add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+# This file exists to keep dependabot happy:
+# https://github.com/dependabot/dependabot-core/issues/4483
+from setuptools import setup
+setup()


### PR DESCRIPTION
The Python build tools are fine without a setup.py but Dependabot
chokes: https://github.com/dependabot/dependabot-core/issues/4483

Add a setup.py to keep Dependabot happy.

Fixes #1828

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


